### PR TITLE
Baseline updated

### DIFF
--- a/src/Pure.RelationalSchema.Self.Storage.Projection/Pure.RelationalSchema.Self.Storage.Projection.csproj
+++ b/src/Pure.RelationalSchema.Self.Storage.Projection/Pure.RelationalSchema.Self.Storage.Projection.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.6.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.6.0.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Self.Storage.Projection</PackageId>


### PR DESCRIPTION
Bumps `PackageValidationBaselineVersion` to `0.1.0-preview.6.0.1` following the release of that version.